### PR TITLE
Atualizar senha do administrador da VM para usar variável em vez de v…

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -158,7 +158,7 @@ resource "azurerm_virtual_machine" "vm02" {
   os_profile {
     computer_name  = "vm02"
     admin_username = "vmuser"
-    admin_password = "Password1234!"
+    admin_password = var.admin_password
     custom_data    = base64encode(data.template_file.cloud_init.rendered)
   }
   os_profile_linux_config {


### PR DESCRIPTION
This pull request makes a small but important change to the way the admin password is managed for the `vm02` virtual machine resource in the Terraform configuration. Instead of hardcoding the admin password, it now references a variable, improving security and flexibility.

- The `admin_password` field in the `os_profile` block for `azurerm_virtual_machine.vm02` is now set to `var.admin_password` instead of a hardcoded value.